### PR TITLE
build: deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-wallet",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -9,29 +9,27 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
-    "typescript": "^4.1.2",
-    "web-vitals": "^1.0.1"
-  },
-  "dependencies": {
     "@types/reactstrap": "^8.0.1",
     "@zilliqa-js/zilliqa": "3.3.4",
     "bootstrap": "^4.3.1",
     "husky": "^1.3.1",
     "prettier": "^2.3.2",
     "rc-steps": "^3.3.1",
+    "react": "^17.0.2",
     "react-app-rewired": "^2.1.8",
+    "react-dom": "^17.0.2",
     "react-google-recaptcha": "^1.0.5",
     "react-hooks-worker": "^1.0.0",
     "react-icons": "^3.3.0",
     "react-jazzicon": "^0.1.3",
     "react-router-dom": "^5.2.0",
+    "react-scripts": "4.0.3",
     "reactstrap": "^8.0.0",
     "styled-components": "^4.3.2",
     "ts-jest": "^24.0.2",
+    "typescript": "^4.1.2",
     "uuid": "^8.3.2",
+    "web-vitals": "^1.0.1",
     "whatwg-fetch": "^3.0.0",
     "worker-plugin": "^5.0.1"
   },


### PR DESCRIPTION
## Description
This PR puts all dev dependencies in `dependencies`.

<!--- Describe your changes in detail -->

## Motivation and Context

https://stackoverflow.com/questions/44868453/create-react-app-install-devdepencies-in-dependencies-section/44872787#44872787

> This is an intentional change in one of the latest versions.
>
> The distinction is pretty arbitrary for front-end apps that produce static bundles. Technically you don't need any of these dependencies on the server, not even the runtime ones. So by that logic even react might be seen as a development dependency.
>
> We used to try to separate them but as explained above, it isn't really consistent in the first place. There's no technical reason why this distinction is useful for apps that have no Node runtime. In addition, it used to cause problems for some Heroku deployments that didn't install development dependencies (and thus weren't able to build the project on the server or test it right before deployment).
>
> In the end we went with just putting everything into dependencies. If you disagree you can always rearrange package.json as you deem reasonable.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
